### PR TITLE
Fix incorrect native symbol for INR currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Simply a list of ISO-4217 currencies with name, code, symbol, &amp; decimal roun
 ```JavaScript
 
 // include it
-const lib = require('@blossomfinance/iso-4217-currencies');
+const lib = require('@mreduar/iso-4217-currencies');
 
 // get metadata for a specific currency code
 const usd = lib.currency('USD');
@@ -42,7 +42,7 @@ const code = lib.codeForCountry('CM');
 ## Exported API
 
 ```JavaScript
-const lib = require('@blossomfinance/iso-4217-currencies');
+const lib = require('@mreduar/iso-4217-currencies');
 
 const {
   // array of currency codes

--- a/data/iso-4217.json
+++ b/data/iso-4217.json
@@ -560,7 +560,7 @@
   "INR": {
     "symbol": "Rs",
     "name": "Indian Rupee",
-    "symbolNative": "টকা",
+    "symbolNative": "₹",
     "decimalDigits": 2,
     "rounding": 0,
     "code": "INR",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blossomfinance/iso-4217-currencies",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blossomfinance/iso-4217-currencies",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "devDependencies": {
         "faker": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@blossomfinance/iso-4217-currencies",
+  "name": "@mreduar/iso-4217-currencies",
   "description": "Simply a list of ISO-4217 currencies with name, code, symbol, &amp; decimal rounding",
   "version": "0.2.5",
   "main": "index.js",
@@ -18,11 +18,11 @@
     "build:countries": "node bin/fill-currencies.js > tmp/iso-4217.json && mv tmp/iso-4217.json data/iso-4217.json",
     "build:currencies": "node bin/fill-countries.js > tmp/iso-3166-1-alpha-2-to-iso-4217.json && mv tmp/iso-3166-1-alpha-2-to-iso-4217.json data/iso-3166-1-alpha-2-to-iso-4217.json",
     "release": "release-it",
-    "test": "./node_modules/.bin/tape test/*.js | node_modules/.bin/tap-spec"
+    "test": "tape test/*.js | node_modules/.bin/tap-spec"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/blossomfinance/iso-4217-currencies.git"
+    "url": "git+https://github.com/mreduar/iso-4217-currencies.git"
   },
   "keywords": [
     "currency",
@@ -39,7 +39,7 @@
   "author": "Matthew J. Martin <matthew@blossomfinance.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/blossomfinance/iso-4217-currencies/issues"
+    "url": "https://github.com/mreduar/iso-4217-currencies/issues"
   },
-  "homepage": "https://github.com/blossomfinance/iso-4217-currencies#readme"
+  "homepage": "https://github.com/mreduar/iso-4217-currencies#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mreduar/iso-4217-currencies",
   "description": "Simply a list of ISO-4217 currencies with name, code, symbol, &amp; decimal rounding",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "index.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
This PR corrects the symbolNative field for the INR (Indian Rupee) currency. The current symbol "টকা" is associated with the Bangladeshi Taka and not the Indian Rupee. The correct native symbol for the INR, "₹", has been updated to reflect the correct currency representation in the ISO-4217 currency list.

https://en.wikipedia.org/wiki/Indian_rupee_sign